### PR TITLE
Implement simple GPX upload viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-New Repo
+# GPX Viewer
+
+Simple Flask application to upload a GPX file and show basic statistics.
+
+## Usage
+
+1. Install Flask if not already installed:
+   ```bash
+   pip install Flask
+   ```
+2. Run the server:
+   ```bash
+   python3 app.py
+   ```
+3. Open `http://localhost:5000` in your browser and upload a `.gpx` file.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+from flask import Flask, request, render_template
+from gpxutils import parse_gpx
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    if 'gpxfile' not in request.files:
+        return 'No file part', 400
+    file = request.files['gpxfile']
+    if file.filename == '':
+        return 'No selected file', 400
+    stats = parse_gpx(file)
+    return render_template('result.html', stats=stats)
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/gpxutils.py
+++ b/gpxutils.py
@@ -1,0 +1,42 @@
+import xml.etree.ElementTree as ET
+import math
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    R = 6371000  # Earth radius in meters
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+    return R * c
+
+
+def parse_gpx(fp):
+    tree = ET.parse(fp)
+    root = tree.getroot()
+    ns = {'gpx': 'http://www.topografix.com/GPX/1/1'}
+    trackpoints = []
+    for trkpt in root.findall('.//gpx:trkpt', ns):
+        lat = float(trkpt.attrib.get('lat'))
+        lon = float(trkpt.attrib.get('lon'))
+        trackpoints.append((lat, lon))
+
+    stats = {
+        'points': len(trackpoints),
+    }
+    if trackpoints:
+        lats = [p[0] for p in trackpoints]
+        lons = [p[1] for p in trackpoints]
+        stats['bounds'] = {
+            'min_lat': min(lats),
+            'max_lat': max(lats),
+            'min_lon': min(lons),
+            'max_lon': max(lons),
+        }
+        dist = 0
+        for i in range(1, len(trackpoints)):
+            dist += haversine(trackpoints[i-1][0], trackpoints[i-1][1], trackpoints[i][0], trackpoints[i][1])
+        stats['distance_m'] = dist
+    return stats

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>GPX Uploader</title>
+</head>
+<body>
+  <h1>Upload GPX File</h1>
+  <form action="/upload" method="post" enctype="multipart/form-data">
+    <input type="file" name="gpxfile" accept=".gpx">
+    <input type="submit" value="Upload">
+  </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>GPX Result</title>
+</head>
+<body>
+  <h1>GPX Analysis</h1>
+  {% if stats.points %}
+  <p>Total trackpoints: {{ stats.points }}</p>
+  <p>Total distance: {{ '%.1f'|format(stats.distance_m) }} meters</p>
+  <h2>Bounds</h2>
+  <ul>
+    <li>Min Lat: {{ stats.bounds.min_lat }}</li>
+    <li>Max Lat: {{ stats.bounds.max_lat }}</li>
+    <li>Min Lon: {{ stats.bounds.min_lon }}</li>
+    <li>Max Lon: {{ stats.bounds.max_lon }}</li>
+  </ul>
+  {% else %}
+  <p>No trackpoints found in GPX.</p>
+  {% endif %}
+  <a href="/">Upload another file</a>
+</body>
+</html>

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,8 @@
+import gpxutils
+
+
+def test_parse():
+    with open('testdata/sample.gpx') as f:
+        stats = gpxutils.parse_gpx(f)
+    assert stats['points'] == 2
+    assert round(stats['distance_m'], 1) > 0

--- a/testdata/sample.gpx
+++ b/testdata/sample.gpx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <name>Example GPX</name>
+    <trkseg>
+      <trkpt lat="35.0" lon="135.0"></trkpt>
+      <trkpt lat="35.1" lon="135.1"></trkpt>
+    </trkseg>
+  </trk>
+</gpx>


### PR DESCRIPTION
## Summary
- add Flask app to upload a GPX file and parse it
- parse GPX using a small utility module without external deps
- provide HTML templates for file upload and result display
- include a minimal sample GPX and a test for the parser
- update README with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e0200d00833189f677772a2db2c5