### PR TITLE
Improve GPX parser to handle attribute order

### DIFF
--- a/gpxutils.js
+++ b/gpxutils.js
@@ -12,15 +12,18 @@ function haversine(lat1, lon1, lat2, lon2) {
 
 function parseGpx(text) {
   const trackpoints = [];
-  const regex = /<trkpt[^>]*lat="([^"]+)"[^>]*lon="([^"]+)"[^>]*(?:>(.*?)<\/trkpt>|\/>)/gs;
+  const regex = /<trkpt\b([^>]*)(?:\/>|>([\s\S]*?)<\/trkpt>)/g;
   let match;
   while ((match = regex.exec(text)) !== null) {
+    const attrs = match[1];
+    const content = match[2] || '';
+    const latMatch = /lat="([^"]+)"/.exec(attrs);
+    const lonMatch = /lon="([^"]+)"/.exec(attrs);
+    if (!latMatch || !lonMatch) continue;
     let ele = null;
-    if (match[3]) {
-      const eleMatch = /<ele>([^<]+)<\/ele>/i.exec(match[3]);
-      if (eleMatch) ele = parseFloat(eleMatch[1]);
-    }
-    trackpoints.push([parseFloat(match[1]), parseFloat(match[2]), ele]);
+    const eleMatch = /<ele>([^<]+)<\/ele>/i.exec(content);
+    if (eleMatch) ele = parseFloat(eleMatch[1]);
+    trackpoints.push([parseFloat(latMatch[1]), parseFloat(lonMatch[1]), ele]);
   }
   const stats = { points: trackpoints.length };
   if (trackpoints.length > 0) {

--- a/test_gpxutils.js
+++ b/test_gpxutils.js
@@ -2,12 +2,17 @@ const fs = require('fs');
 const assert = require('assert');
 const { parseGpx } = require('./gpxutils.js');
 
-const data = fs.readFileSync('testdata/sample.gpx', 'utf8');
-const stats = parseGpx(data);
+let data = fs.readFileSync('testdata/sample.gpx', 'utf8');
+let stats = parseGpx(data);
 assert.strictEqual(stats.points, 5);
 assert(stats.distance_m > 3900 && stats.distance_m < 4100);
 assert.strictEqual(stats.trackpoints.length, 5);
 assert.strictEqual(stats.per_km_elevation.length, 4);
 assert.strictEqual(stats.per_km_elevation[0].gain, 10);
 assert.strictEqual(stats.per_km_elevation[1].loss, 5);
+
+data = fs.readFileSync('testdata/reverse.gpx', 'utf8');
+stats = parseGpx(data);
+assert.strictEqual(stats.points, 2);
+assert.strictEqual(stats.trackpoints.length, 2);
 console.log('All tests passed');

--- a/testdata/reverse.gpx
+++ b/testdata/reverse.gpx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <trkseg>
+      <trkpt lon="135.000" lat="35.0"><ele>100</ele></trkpt>
+      <trkpt lon="135.011" lat="35.0"><ele>110</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>


### PR DESCRIPTION
## Summary
- make GPX parsing independent of attribute order
- add reversed GPX fixture
- add tests for new fixture

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ebff98108331872d073bb06c6a8e