### PR TITLE
Add Chart.js elevation profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GPX Viewer
 
 Simple Node.js and Express application to upload a GPX file and show basic statistics.
+It draws the track and an elevation profile using Chart.js loaded from a CDN.
 
 ## Usage
 

--- a/gpxutils.js
+++ b/gpxutils.js
@@ -12,15 +12,18 @@ function haversine(lat1, lon1, lat2, lon2) {
 
 function parseGpx(text) {
   const trackpoints = [];
-  const regex = /<trkpt[^>]*lat="([^"]+)"[^>]*lon="([^"]+)"[^>]*(?:>(.*?)<\/trkpt>|\/>)/gs;
+  const regex = /<trkpt\b([^>]*)(?:\/>|>([\s\S]*?)<\/trkpt>)/g;
   let match;
   while ((match = regex.exec(text)) !== null) {
+    const attrs = match[1];
+    const content = match[2] || '';
+    const latMatch = /lat="([^"]+)"/.exec(attrs);
+    const lonMatch = /lon="([^"]+)"/.exec(attrs);
+    if (!latMatch || !lonMatch) continue;
     let ele = null;
-    if (match[3]) {
-      const eleMatch = /<ele>([^<]+)<\/ele>/i.exec(match[3]);
-      if (eleMatch) ele = parseFloat(eleMatch[1]);
-    }
-    trackpoints.push([parseFloat(match[1]), parseFloat(match[2]), ele]);
+    const eleMatch = /<ele>([^<]+)<\/ele>/i.exec(content);
+    if (eleMatch) ele = parseFloat(eleMatch[1]);
+    trackpoints.push([parseFloat(latMatch[1]), parseFloat(lonMatch[1]), ele]);
   }
   const stats = { points: trackpoints.length };
   if (trackpoints.length > 0) {
@@ -34,6 +37,7 @@ function parseGpx(text) {
     };
     let dist = 0;
     const perKm = [];
+    const profile = [[0, trackpoints[0][2]]];
     for (let i = 1; i < trackpoints.length; i++) {
       const kmIndex = Math.floor(dist / 1000);
       if (!perKm[kmIndex]) {
@@ -46,9 +50,11 @@ function parseGpx(text) {
         if (diff > 0) perKm[kmIndex].gain += diff; else perKm[kmIndex].loss += -diff;
       }
       dist += haversine(trackpoints[i-1][0], trackpoints[i-1][1], trackpoints[i][0], trackpoints[i][1]);
+      profile.push([dist, trackpoints[i][2]]);
     }
     stats.distance_m = dist;
     stats.per_km_elevation = perKm;
+    stats.profile = profile;
   }
   stats.trackpoints = trackpoints;
   return stats;

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -18,6 +18,8 @@
   </ul>
   <h2>Track</h2>
   <svg id="track" width="400" height="400" style="border:1px solid #ccc"></svg>
+  <h2>Elevation Profile</h2>
+  <canvas id="elevChart" width="600" height="300"></canvas>
   <h2>Elevation per KM</h2>
   <ul>
     <% (stats.per_km_elevation || []).forEach(function(seg) { %>
@@ -44,6 +46,34 @@
       poly.setAttribute('stroke', 'blue');
       poly.setAttribute('fill', 'none');
       document.getElementById('track').appendChild(poly);
+    }
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>
+    const profile = <%- JSON.stringify(stats.profile || []) %>;
+    if (profile.length > 1) {
+      const ctx = document.getElementById('elevChart').getContext('2d');
+      const labels = profile.map(p => (p[0] / 1000).toFixed(2));
+      const elev = profile.map(p => p[1]);
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: labels,
+          datasets: [{
+            label: 'Elevation (m)',
+            data: elev,
+            borderColor: 'blue',
+            fill: false,
+            pointRadius: 0
+          }]
+        },
+        options: {
+          scales: {
+            x: { title: { display: true, text: 'Distance (km)' } },
+            y: { title: { display: true, text: 'Elevation (m)' } }
+          }
+        }
+      });
     }
   </script>
   <% } else { %>

--- a/test_gpxutils.js
+++ b/test_gpxutils.js
@@ -2,12 +2,23 @@ const fs = require('fs');
 const assert = require('assert');
 const { parseGpx } = require('./gpxutils.js');
 
-const data = fs.readFileSync('testdata/sample.gpx', 'utf8');
-const stats = parseGpx(data);
+let data = fs.readFileSync('testdata/sample.gpx', 'utf8');
+let stats = parseGpx(data);
 assert.strictEqual(stats.points, 5);
 assert(stats.distance_m > 3900 && stats.distance_m < 4100);
 assert.strictEqual(stats.trackpoints.length, 5);
 assert.strictEqual(stats.per_km_elevation.length, 4);
 assert.strictEqual(stats.per_km_elevation[0].gain, 10);
 assert.strictEqual(stats.per_km_elevation[1].loss, 5);
+
+data = fs.readFileSync('testdata/reverse.gpx', 'utf8');
+stats = parseGpx(data);
+assert.strictEqual(stats.points, 2);
+assert.strictEqual(stats.trackpoints.length, 2);
+
+data = fs.readFileSync('testdata/mmp8th_long.gpx', 'utf8');
+stats = parseGpx(data);
+assert(stats.points > 5);
+assert.strictEqual(stats.profile.length, stats.trackpoints.length);
+
 console.log('All tests passed');

--- a/testdata/mmp8th_long.gpx
+++ b/testdata/mmp8th_long.gpx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <trkseg>
+      <trkpt lat="35.0" lon="135.000"><ele>100</ele></trkpt>
+      <trkpt lat="35.0" lon="135.010"><ele>110</ele></trkpt>
+      <trkpt lat="35.0" lon="135.020"><ele>120</ele></trkpt>
+      <trkpt lat="35.0" lon="135.030"><ele>115</ele></trkpt>
+      <trkpt lat="35.0" lon="135.040"><ele>125</ele></trkpt>
+      <trkpt lat="35.0" lon="135.050"><ele>130</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/testdata/reverse.gpx
+++ b/testdata/reverse.gpx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <trkseg>
+      <trkpt lon="135.000" lat="35.0"><ele>100</ele></trkpt>
+      <trkpt lon="135.011" lat="35.0"><ele>110</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>


### PR DESCRIPTION
## Summary
- compute distance/elevation profile while parsing GPX
- include mmp8th_long.gpx test fixture
- render elevation profile chart with Chart.js

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6867ebff98108331872d073bb06c6a8e