### PR TITLE
Fix API key warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ It draws the track and an elevation profile using Chart.js loaded from a CDN.
    ```bash
    npm install
    ```
-2. Run the server:
+2. Set a Google Maps API key in the environment so the map can load. If the key is not provided the result page shows a warning and the map will not appear, but the elevation chart will still be drawn:
+   ```bash
+   export GOOGLE_MAPS_API_KEY=YOUR_KEY_HERE
+   ```
+3. Run the server:
    ```bash
    node app.js
    ```
-3. Open `http://localhost:5000` in your browser and upload a `.gpx` file.
+4. Open `http://localhost:5000` in your browser and upload a `.gpx` file.

--- a/app.js
+++ b/app.js
@@ -19,7 +19,7 @@ app.post('/upload', upload.single('gpxfile'), async (req, res) => {
   }
   try {
     const stats = parseGpx(req.file.buffer.toString());
-    res.render('result', { stats });
+    res.render('result', { stats, googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY });
   } catch (err) {
     res.status(400).send('Failed to parse GPX');
   }

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -19,7 +19,7 @@
   <h2>Track</h2>
   <div id="map" style="width:600px;height:400px;border:1px solid #ccc"></div>
   <h2>Elevation Profile</h2>
-  <canvas id="elevChart" width="600" height="300"></canvas>
+  <canvas id="elevChart" width="300" height="150"></canvas>
   <h2>Elevation per KM</h2>
   <ul>
     <% (stats.per_km_elevation || []).forEach(function(seg) { %>
@@ -96,40 +96,19 @@
       });
     }
 
-    window.initMap = function() {
-      createMap();
-      initChart();
-    };
-  </script>
-  <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script>
-    const profile = <%- JSON.stringify(stats.profile || []) %>;
-    if (profile.length > 1) {
-      const ctx = document.getElementById('elevChart').getContext('2d');
-      const labels = profile.map(p => (p[0] / 1000).toFixed(2));
-      const elev = profile.map(p => p[1]);
-      new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: labels,
-          datasets: [{
-            label: 'Elevation (m)',
-            data: elev,
-            borderColor: 'blue',
-            fill: false,
-            pointRadius: 0
-          }]
-        },
-        options: {
-          scales: {
-            x: { title: { display: true, text: 'Distance (km)' } },
-            y: { title: { display: true, text: 'Elevation (m)' } }
-          }
-        }
-      });
-    }
-  </script>
+  window.initMap = function() {
+    createMap();
+    initChart();
+  };
+</script>
+<% if (googleMapsApiKey) { %>
+<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= googleMapsApiKey %>&callback=initMap"></script>
+<% } else { %>
+<p style="color:red">Google Maps API key not set</p>
+<script>
+  document.addEventListener('DOMContentLoaded', initChart);
+</script>
+<% } %>
   <% } else { %>
   <p>No trackpoints found in GPX.</p>
   <% } %>


### PR DESCRIPTION
## Summary
- show warning if Google Maps API key is missing
- document that the map only works when the key is set
- draw the elevation chart even when the API key is missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867f347b0ec83318f0bb6e728627e27