### PR TITLE
Add elevation stats and update viewer

### DIFF
--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -10,13 +10,10 @@
   <% if (stats.points) { %>
   <p>Total trackpoints: <%= stats.points %></p>
   <p>Total distance: <%= stats.distance_m.toFixed(1) %> meters</p>
-  <h2>Bounds</h2>
-  <ul>
-    <li>Min Lat: <%= stats.bounds.min_lat %></li>
-    <li>Max Lat: <%= stats.bounds.max_lat %></li>
-    <li>Min Lon: <%= stats.bounds.min_lon %></li>
-    <li>Max Lon: <%= stats.bounds.max_lon %></li>
-  </ul>
+  <p>Highest elevation: <%= stats.highest_elevation_m != null ? stats.highest_elevation_m.toFixed(1) : 'N/A' %> m</p>
+  <p>Lowest elevation: <%= stats.lowest_elevation_m != null ? stats.lowest_elevation_m.toFixed(1) : 'N/A' %> m</p>
+  <p>Total gain: <%= stats.total_gain_m.toFixed(1) %> m</p>
+  <p>Total loss: <%= stats.total_loss_m.toFixed(1) %> m</p>
   <div id="layout" style="display:flex;align-items:flex-start;gap:10px;">
     <div id="left-panel">
       <h2>Track</h2>
@@ -24,8 +21,9 @@
       <h2>Elevation Profile</h2>
       <label for="yScale">Y-Axis Max:</label>
       <select id="yScale">
-        <% for (let v = 1000; v <= 10000; v += 1000) { %>
-          <option value="<%= v %>" <%= v === 5000 ? 'selected' : '' %>><%= v %>m</option>
+        <% const initY = Math.min(3000, Math.max(500, Math.ceil((stats.highest_elevation_m || 0) / 500) * 500)); %>
+        <% for (let v = 500; v <= 3000; v += 500) { %>
+          <option value="<%= v %>" <%= v === initY ? 'selected' : '' %>><%= v %>m</option>
         <% } %>
       </select>
       <canvas id="elevChart" width="900" height="450"></canvas>

--- a/test_gpxutils.js
+++ b/test_gpxutils.js
@@ -10,15 +10,26 @@ assert.strictEqual(stats.trackpoints.length, 5);
 assert.strictEqual(stats.per_km_elevation.length, 4);
 assert.strictEqual(stats.per_km_elevation[0].gain, 10);
 assert.strictEqual(stats.per_km_elevation[1].loss, 5);
+assert.strictEqual(stats.highest_elevation_m, 115);
+assert.strictEqual(stats.lowest_elevation_m, 100);
+assert.strictEqual(Math.round(stats.total_gain_m), 20);
+assert.strictEqual(Math.round(stats.total_loss_m), 10);
 
 data = fs.readFileSync('testdata/reverse.gpx', 'utf8');
 stats = parseGpx(data);
 assert.strictEqual(stats.points, 2);
 assert.strictEqual(stats.trackpoints.length, 2);
+assert.strictEqual(stats.highest_elevation_m, 110);
+assert.strictEqual(stats.lowest_elevation_m, 100);
+assert.strictEqual(Math.round(stats.total_gain_m), 10);
+assert.strictEqual(Math.round(stats.total_loss_m), 0);
 
 data = fs.readFileSync('testdata/mmp8th_long.gpx', 'utf8');
 stats = parseGpx(data);
 assert(stats.points > 5);
 assert.strictEqual(stats.profile.length, stats.trackpoints.length);
+assert(stats.highest_elevation_m > 1000);
+assert(stats.lowest_elevation_m < 300);
+assert(Math.abs(stats.total_gain_m - stats.total_loss_m) < 1);
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- compute highest/lowest elevation and total gain/loss in `parseGpx`
- show elevation stats in the result page and drop bounds section
- limit Y-axis selector to 500–3000m with default just above max elevation
- update tests for new fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868828d0fe88331b9395863aa4907bd