### PR TITLE
Add slope time analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ It draws the track and an elevation profile using Chart.js loaded from a CDN.
    ```bash
    node app.js
    ```
-4. Open `http://localhost:8180` in your browser and upload a `.gpx` file.
+4. Open `http://localhost:8180` in your browser and upload a `.gpx` file. You can
+   set uphill and downhill slope thresholds on the upload form. The results page
+   shows how much time was spent on sections steeper than those thresholds and
+   provides a button to download the JSON summary.
 
 ### Command line analysis
 
@@ -32,4 +35,5 @@ node analyze.js path/to/file.gpx 10 10
 
 The example above calculates how many seconds were spent on kilometers where the
 uphill grade was at least 10% and where the downhill grade was at least 10%.
-The result is printed as JSON.
+The result is printed as JSON. The same analysis is available in the web
+interface via the upload form.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ It draws the track and an elevation profile using Chart.js loaded from a CDN.
    node app.js
    ```
 4. Open `http://localhost:8180` in your browser and upload a `.gpx` file.
+
+### Command line analysis
+
+You can analyze a GPX file from the command line to measure the time spent on
+steep climbs or descents. Provide thresholds in percent for the slope over each
+kilometer:
+
+```bash
+node analyze.js path/to/file.gpx 10 10
+```
+
+The example above calculates how many seconds were spent on kilometers where the
+uphill grade was at least 10% and where the downhill grade was at least 10%.
+The result is printed as JSON.

--- a/analyze.js
+++ b/analyze.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const { parseGpx, analyzeSlopeTime } = require('./gpxutils');
+
+const [,, file, upStr, downStr] = process.argv;
+if (!file || !upStr || !downStr) {
+  console.error('Usage: node analyze.js <file.gpx> <up_threshold_percent> <down_threshold_percent>');
+  process.exit(1);
+}
+
+try {
+  const data = fs.readFileSync(file, 'utf8');
+  const stats = parseGpx(data);
+  const result = analyzeSlopeTime(stats, parseFloat(upStr), parseFloat(downStr));
+  console.log(JSON.stringify(result, null, 2));
+} catch (err) {
+  console.error('Failed to analyze:', err.message);
+  process.exit(1);
+}

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const multer = require('multer');
 const path = require('path');
-const { parseGpx } = require('./gpxutils.js');
+const { parseGpx, analyzeSlopeTime } = require('./gpxutils.js');
 
 const app = express();
 const upload = multer();
@@ -20,11 +20,18 @@ app.post('/upload', upload.single('gpxfile'), async (req, res) => {
   }
   try {
     const stats = parseGpx(req.file.buffer.toString());
+    const up = parseFloat(req.body.up_threshold);
+    const down = parseFloat(req.body.down_threshold);
+    const slopeData = analyzeSlopeTime(
+      stats,
+      Number.isFinite(up) ? up : 0,
+      Number.isFinite(down) ? down : 0
+    );
     const apiKey = process.env.GOOGLE_MAPS_API_KEY ||
                    process.env.GOOGLEMAPS_API_KEY ||
                    process.env.GOOGLE_MAP_API_KEY;
     console.log('apikei:' + apiKey );
-    res.render('result', { stats, googleMapsApiKey: apiKey });
+    res.render('result', { stats, googleMapsApiKey: apiKey, slopeData });
   } catch (err) {
     res.status(400).send('Failed to parse GPX');
   }

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -7,7 +7,9 @@
 <body>
   <h1>Upload GPX File</h1>
   <form action="/upload" method="post" enctype="multipart/form-data">
-    <input type="file" name="gpxfile" accept=".gpx">
+    <input type="file" name="gpxfile" accept=".gpx"><br>
+    <label>Uphill threshold (%): <input type="number" name="up_threshold" value="10" step="1"></label><br>
+    <label>Downhill threshold (%): <input type="number" name="down_threshold" value="10" step="1"></label><br>
     <input type="submit" value="Upload">
   </form>
 </body>

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -23,6 +23,9 @@
   <p>Lowest elevation: <%= stats.lowest_elevation_m != null ? stats.lowest_elevation_m.toFixed(1) : 'N/A' %> m</p>
   <p>Total gain: <%= stats.total_gain_m.toFixed(1) %> m</p>
   <p>Total loss: <%= stats.total_loss_m.toFixed(1) %> m</p>
+  <p>Uphill threshold: <%= slopeData.up_threshold %>% - time: <%= slopeData.up_time_s.toFixed(1) %> s</p>
+  <p>Downhill threshold: <%= slopeData.down_threshold %>% - time: <%= slopeData.down_time_s.toFixed(1) %> s</p>
+  <button id="downloadBtn">Download analysis JSON</button>
   <div id="layout" style="display:flex;align-items:flex-start;gap:10px;">
     <div id="left-panel">
       <h2>Track</h2>
@@ -46,6 +49,7 @@
     const points = <%- JSON.stringify(stats.trackpoints || []) %>;
     const profile = <%- JSON.stringify(stats.profile || []) %>;
     const perKmData = <%- JSON.stringify(stats.per_km_elevation || []) %>;
+    const slopeData = <%- JSON.stringify(slopeData || {}) %>;
     perKmData.forEach(row => {
       const diff = row.gain - row.loss;
       let arrow, cls;
@@ -187,6 +191,18 @@
     initChart();
     initTable();
   };
+
+  document.getElementById('downloadBtn').addEventListener('click', function() {
+    const blob = new Blob([JSON.stringify(slopeData, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'slope_analysis.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  });
 </script>
 <% if (googleMapsApiKey) { %>
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= googleMapsApiKey %>&callback=initMap"></script>


### PR DESCRIPTION
## Summary
- parse trackpoint times and compute distance per point
- accumulate per-kilometer durations
- add CLI helper `analyze.js` to summarize time spent on steep sections
- document CLI usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686886b0402c833189f3a51731559ad4