### PR TITLE
Implement segment rate summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const multer = require('multer');
 const path = require('path');
-const { parseGpx, analyzeSlopeTime } = require('./gpxutils.js');
+const { parseGpx, analyzeSlopeTime, analyzeSegments } = require('./gpxutils.js');
 
 const app = express();
 const upload = multer();
@@ -27,11 +27,12 @@ app.post('/upload', upload.single('gpxfile'), async (req, res) => {
       Number.isFinite(up) ? up : 0,
       Number.isFinite(down) ? down : 0
     );
+    const segmentSummary = analyzeSegments(stats);
     const apiKey = process.env.GOOGLE_MAPS_API_KEY ||
                    process.env.GOOGLEMAPS_API_KEY ||
                    process.env.GOOGLE_MAP_API_KEY;
     console.log('apikei:' + apiKey );
-    res.render('result', { stats, googleMapsApiKey: apiKey, slopeData });
+    res.render('result', { stats, googleMapsApiKey: apiKey, slopeData, segmentSummary });
   } catch (err) {
     res.status(400).send('Failed to parse GPX');
   }

--- a/segment_analysis.js
+++ b/segment_analysis.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const { parseGpx, analyzeSegments } = require('./gpxutils');
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node segment_analysis.js <file.gpx>');
+  process.exit(1);
+}
+
+try {
+  const data = fs.readFileSync(file, 'utf8');
+  const stats = parseGpx(data);
+  const { segments, summary } = analyzeSegments(stats);
+
+  console.log('KM\tDist(m)\tGain(m)\tLoss(m)\tUpRate(%)\tDownRate(%)\tNetRate(%)\tSpeed(km/h)');
+  segments.forEach((seg, i) => {
+    const speedStr = seg.speed_kmh == null ? '-' : seg.speed_kmh.toFixed(2);
+    console.log(`${i + 1}\t${seg.dist_m.toFixed(0)}\t${seg.gain_m.toFixed(2)}\t${seg.loss_m.toFixed(2)}\t${seg.up_rate.toFixed(2)}\t${seg.down_rate.toFixed(2)}\t${seg.net_rate.toFixed(2)}\t${speedStr}`);
+  });
+
+  console.log('Group\tAvgNetRate(%)\tAvgSpeed(km/h)');
+  summary.forEach(row => {
+    if (row.avg_net_rate == null) {
+      console.log(`${row.label}\t-\t-`);
+    } else {
+      const rateStr = row.avg_net_rate.toFixed(2);
+      const speedStr = row.avg_speed == null ? '-' : row.avg_speed.toFixed(2);
+      console.log(`${row.label}\t${rateStr}\t${speedStr}`);
+    }
+  });
+} catch (err) {
+  console.error('Failed to analyze:', err.message);
+  process.exit(1);
+}

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -41,8 +41,16 @@
       <canvas id="elevChart" width="900" height="450"></canvas>
     </div>
     <div id="right-panel">
-      <h2>Elevation per KM</h2>
-      <div id="perKmTable" style="width:300px;"></div>
+      <div style="display:flex;gap:10px;">
+        <div>
+          <h2>Elevation per KM</h2>
+          <div id="perKmTable" style="width:300px;"></div>
+        </div>
+        <div>
+          <h2>Rate Groups</h2>
+          <div id="segmentTable" style="width:300px;"></div>
+        </div>
+      </div>
     </div>
   </div>
   <script>
@@ -50,6 +58,7 @@
     const profile = <%- JSON.stringify(stats.profile || []) %>;
     const perKmData = <%- JSON.stringify(stats.per_km_elevation || []) %>;
     const slopeData = <%- JSON.stringify(slopeData || {}) %>;
+    const segmentData = <%- JSON.stringify(segmentSummary || {}) %>;
     perKmData.forEach(row => {
       const diff = row.gain - row.loss;
       let arrow, cls;
@@ -173,17 +182,29 @@
     }
 
     function initTable() {
-      if (!perKmData || !perKmData.length) return;
-      new Tabulator('#perKmTable', {
-        data: perKmData,
-        layout: 'fitColumns',
-        columns: [
-          { title: '', field: 'trend', formatter: 'html', hozAlign: 'center', width: 40 },
-          { title: 'KM', field: 'km' },
-          { title: 'Gain (m)', field: 'gain', formatter: cell => cell.getValue().toFixed(1) },
-          { title: 'Loss (m)', field: 'loss', formatter: cell => cell.getValue().toFixed(1) }
-        ]
-      });
+      if (perKmData && perKmData.length) {
+        new Tabulator('#perKmTable', {
+          data: perKmData,
+          layout: 'fitColumns',
+          columns: [
+            { title: '', field: 'trend', formatter: 'html', hozAlign: 'center', width: 40 },
+            { title: 'KM', field: 'km' },
+            { title: 'Gain (m)', field: 'gain', formatter: cell => cell.getValue().toFixed(1) },
+            { title: 'Loss (m)', field: 'loss', formatter: cell => cell.getValue().toFixed(1) }
+          ]
+        });
+      }
+      if (segmentData && segmentData.summary) {
+        new Tabulator('#segmentTable', {
+          data: segmentData.summary,
+          layout: 'fitColumns',
+          columns: [
+            { title: 'Group', field: 'label' },
+            { title: 'Avg Net Rate (%)', field: 'avg_net_rate', formatter: cell => cell.getValue() == null ? '-' : cell.getValue().toFixed(2) },
+            { title: 'Avg Speed (km/h)', field: 'avg_speed', formatter: cell => cell.getValue() == null ? '-' : cell.getValue().toFixed(2) }
+          ]
+        });
+      }
     }
 
   window.initMap = function() {


### PR DESCRIPTION
## Summary
- add `analyzeSegments` to compute rate and speed per km and group by net ascent
- expose new summary on the result page beside the per‑km table
- update CLI script to reuse the utility function

## Testing
- `npm test`
- `node segment_analysis.js testdata/mmp8th_long.gpx`

------
https://chatgpt.com/codex/tasks/task_e_68688c38ad708331a6110cbf29081426