### PR TITLE
Fix net rate grouping in Rate Groups

### DIFF
--- a/gpxutils.js
+++ b/gpxutils.js
@@ -147,15 +147,16 @@ function analyzeSegments(stats) {
   ];
 
   segments.forEach(seg => {
-    const rate = seg.net_rate < 0 ? 0 : seg.net_rate;
-    const grp = ranges.find(r => rate >= r.min && rate < r.max);
+    const clampedRate = seg.net_rate < 0 ? 0 : seg.net_rate;
+    seg._clamped_rate = clampedRate;
+    const grp = ranges.find(r => clampedRate >= r.min && clampedRate < r.max);
     if (grp) grp.segs.push(seg);
   });
 
   const summary = ranges.map(r => {
     const cnt = r.segs.length;
     if (!cnt) return { label: r.label, avg_net_rate: null, avg_speed: null };
-    const avgRate = r.segs.reduce((s, x) => s + x.net_rate, 0) / cnt;
+    const avgRate = r.segs.reduce((s, x) => s + x._clamped_rate, 0) / cnt;
     const spdSegs = r.segs.filter(x => x.speed_kmh != null);
     const avgSpeed = spdSegs.length
       ? spdSegs.reduce((s, x) => s + x.speed_kmh, 0) / spdSegs.length


### PR DESCRIPTION
## Summary
- avoid negative net rate dragging down rate groups
- compute summary averages based on clamped non-negative net rate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686891b3ec948331aa31a58f3a981d74