### PR TITLE
Remove slope threshold inputs and add rate group JSON

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const multer = require('multer');
 const path = require('path');
-const { parseGpx, analyzeSlopeTime, analyzeSegments } = require('./gpxutils.js');
+const { parseGpx, analyzeSegments } = require('./gpxutils.js');
 
 const app = express();
 const upload = multer();
@@ -20,19 +20,12 @@ app.post('/upload', upload.single('gpxfile'), async (req, res) => {
   }
   try {
     const stats = parseGpx(req.file.buffer.toString());
-    const up = parseFloat(req.body.up_threshold);
-    const down = parseFloat(req.body.down_threshold);
-    const slopeData = analyzeSlopeTime(
-      stats,
-      Number.isFinite(up) ? up : 0,
-      Number.isFinite(down) ? down : 0
-    );
     const segmentSummary = analyzeSegments(stats);
     const apiKey = process.env.GOOGLE_MAPS_API_KEY ||
                    process.env.GOOGLEMAPS_API_KEY ||
                    process.env.GOOGLE_MAP_API_KEY;
     console.log('apikei:' + apiKey );
-    res.render('result', { stats, googleMapsApiKey: apiKey, slopeData, segmentSummary });
+    res.render('result', { stats, googleMapsApiKey: apiKey, segmentSummary });
   } catch (err) {
     res.status(400).send('Failed to parse GPX');
   }

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -8,8 +8,6 @@
   <h1>Upload GPX File</h1>
   <form action="/upload" method="post" enctype="multipart/form-data">
     <input type="file" name="gpxfile" accept=".gpx"><br>
-    <label>Uphill threshold (%): <input type="number" name="up_threshold" value="10" step="1"></label><br>
-    <label>Downhill threshold (%): <input type="number" name="down_threshold" value="10" step="1"></label><br>
     <input type="submit" value="Upload">
   </form>
 </body>

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -23,9 +23,6 @@
   <p>Lowest elevation: <%= stats.lowest_elevation_m != null ? stats.lowest_elevation_m.toFixed(1) : 'N/A' %> m</p>
   <p>Total gain: <%= stats.total_gain_m.toFixed(1) %> m</p>
   <p>Total loss: <%= stats.total_loss_m.toFixed(1) %> m</p>
-  <p>Uphill threshold: <%= slopeData.up_threshold %>% - time: <%= slopeData.up_time_s.toFixed(1) %> s</p>
-  <p>Downhill threshold: <%= slopeData.down_threshold %>% - time: <%= slopeData.down_time_s.toFixed(1) %> s</p>
-  <button id="downloadBtn">Download analysis JSON</button>
   <div id="layout" style="display:flex;align-items:flex-start;gap:10px;">
     <div id="left-panel">
       <h2>Track</h2>
@@ -46,18 +43,18 @@
           <h2>Elevation per KM</h2>
           <div id="perKmTable" style="width:300px;"></div>
         </div>
-        <div>
-          <h2>Rate Groups</h2>
-          <div id="segmentTable" style="width:300px;"></div>
+          <div>
+            <h2>Rate Groups</h2>
+            <div id="segmentTable" style="width:300px;"></div>
+            <button id="downloadRateBtn">Download JSON</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
   <script>
     const points = <%- JSON.stringify(stats.trackpoints || []) %>;
     const profile = <%- JSON.stringify(stats.profile || []) %>;
     const perKmData = <%- JSON.stringify(stats.per_km_elevation || []) %>;
-    const slopeData = <%- JSON.stringify(slopeData || {}) %>;
     const segmentData = <%- JSON.stringify(segmentSummary || {}) %>;
     perKmData.forEach(row => {
       const diff = row.gain - row.loss;
@@ -213,17 +210,18 @@
     initTable();
   };
 
-  document.getElementById('downloadBtn').addEventListener('click', function() {
-    const blob = new Blob([JSON.stringify(slopeData, null, 2)], { type: 'application/json' });
+  document.getElementById('downloadRateBtn').addEventListener('click', function() {
+    const blob = new Blob([JSON.stringify(segmentData.summary, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'slope_analysis.json';
+    a.download = 'rate_groups.json';
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   });
+
 </script>
 <% if (googleMapsApiKey) { %>
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= googleMapsApiKey %>&callback=initMap"></script>


### PR DESCRIPTION
## Summary
- remove uphill/downhill threshold handling from web UI and server
- drop download analysis JSON button
- add button below Rate Groups table to download that data as JSON

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68689a52d2ac833183b9219aaeb0b781