### PR TITLE
Update layout and segment value alignment

### DIFF
--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -12,17 +12,29 @@
     .down2 { color: #cd5c5c; }
     .down3 { color: #8b0000; }
     .flat { color: #808080; }
+    .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; }
+    .stats-col { flex:1; min-width:200px; line-height:1.2; }
+    .segment-col { min-width:150px; line-height:1.2; }
+    .stat-row { display:flex; justify-content:space-between; margin:2px 0; }
+    .stat-label { flex:1; }
+    .stat-value { margin-left:10px; text-align:right; min-width:70px; }
   </style>
 </head>
 <body>
   <h1>GPX Analysis</h1>
   <% if (stats.points) { %>
-  <p>Total trackpoints: <%= stats.points %></p>
-  <p>Total distance: <%= stats.distance_m.toFixed(1) %> meters</p>
-  <p>Highest elevation: <%= stats.highest_elevation_m != null ? stats.highest_elevation_m.toFixed(1) : 'N/A' %> m</p>
-  <p>Lowest elevation: <%= stats.lowest_elevation_m != null ? stats.lowest_elevation_m.toFixed(1) : 'N/A' %> m</p>
-  <p>Total gain: <%= stats.total_gain_m.toFixed(1) %> m</p>
-  <p>Total loss: <%= stats.total_loss_m.toFixed(1) %> m</p>
+  <div class="stats-grid">
+    <div class="stats-col">
+      <div class="stat-row"><span class="stat-label">Total trackpoints:</span><span class="stat-value"><%= stats.points %></span></div>
+      <div class="stat-row"><span class="stat-label">Total distance:</span><span class="stat-value"><%= stats.distance_m.toFixed(1) %> meters</span></div>
+      <div class="stat-row"><span class="stat-label">Highest elevation:</span><span class="stat-value"><%= stats.highest_elevation_m != null ? stats.highest_elevation_m.toFixed(1) : 'N/A' %> m</span></div>
+    </div>
+    <div class="stats-col">
+      <div class="stat-row"><span class="stat-label">Lowest elevation:</span><span class="stat-value"><%= stats.lowest_elevation_m != null ? stats.lowest_elevation_m.toFixed(1) : 'N/A' %> m</span></div>
+      <div class="stat-row"><span class="stat-label">Total gain:</span><span class="stat-value"><%= stats.total_gain_m.toFixed(1) %> m</span></div>
+      <div class="stat-row"><span class="stat-label">Total loss:</span><span class="stat-value"><%= stats.total_loss_m.toFixed(1) %> m</span></div>
+    </div>
+  </div>
   <div id="layout" style="display:flex;align-items:flex-start;gap:10px;">
     <div id="left-panel">
       <h2>Track</h2>
@@ -51,7 +63,7 @@
         <div>
           <h2>Waypoints</h2>
           <button id="clearWaypointsBtn">Clear</button>
-          <div id="segmentStatsTable" style="width:300px;"></div>
+          <div id="waypointStats" style="display:flex;gap:10px;flex-wrap:wrap;"></div>
         </div>
       </div>
       </div>
@@ -218,7 +230,7 @@
       });
     }
 
-    let perKmTable, segTable, segStatsTable;
+    let perKmTable, segTable;
 
     function initTable() {
       if (perKmData && perKmData.length) {
@@ -250,19 +262,6 @@
           ]
         });
       }
-      segStatsTable = new Tabulator('#segmentStatsTable', {
-        data: [],
-        layout: 'fitColumns',
-        columns: [
-          { title: 'Seg', field: 'idx' },
-          { title: 'Dist (m)', field: 'dist_m', formatter: c => c.getValue().toFixed(1) },
-          { title: 'Gain (m)', field: 'gain_m', formatter: c => c.getValue().toFixed(1) },
-          { title: 'Loss (m)', field: 'loss_m', formatter: c => c.getValue().toFixed(1) },
-          { title: 'Avg Up (%)', field: 'avg_up', formatter: c => c.getValue().toFixed(2) },
-          { title: 'Avg Down (%)', field: 'avg_down', formatter: c => c.getValue().toFixed(2) },
-          { title: 'Pred Time', field: 'pred_time', formatter: c => c.getValue() || '-' }
-        ]
-      });
     }
 
     const ranges = [
@@ -318,7 +317,22 @@
         const stats = computeStats(st, en);
         if (stats) segs.push(Object.assign({ idx: i + 1 }, stats));
       }
-      segStatsTable.setData(segs);
+      const container = document.getElementById('waypointStats');
+      container.innerHTML = '';
+      segs.forEach((seg, i) => {
+        const startLabel = i === 0 ? 'Start' : `WP${i}`;
+        const endLabel = i === segs.length - 1 ? 'Finish' : `WP${i+1}`;
+        const col = document.createElement('div');
+        col.className = 'segment-col';
+        col.innerHTML =
+          `<div class="stat-row"><span class="stat-label">Name:</span><span class="stat-value">${startLabel}-${endLabel}</span></div>` +
+          `<div class="stat-row"><span class="stat-label">Distance:</span><span class="stat-value">${seg.dist_m.toFixed(1)} m</span></div>` +
+          `<div class="stat-row"><span class="stat-label">Elevation Gain:</span><span class="stat-value">${seg.gain_m.toFixed(1)} m</span></div>` +
+          `<div class="stat-row"><span class="stat-label">Elevation Loss:</span><span class="stat-value">${seg.loss_m.toFixed(1)} m</span></div>` +
+          `<div class="stat-row"><span class="stat-label">Average Up:</span><span class="stat-value">${seg.avg_up.toFixed(2)} %</span></div>` +
+          `<div class="stat-row"><span class="stat-label">Average Down:</span><span class="stat-value">${seg.avg_down.toFixed(2)} %</span></div>`;
+        container.appendChild(col);
+      });
     }
 
     function addWaypoint(idx) {


### PR DESCRIPTION
## Summary
- align statistic values to the right of their labels
- update waypoint segment stats to use same right‑aligned layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686901d6a92c8331925bd5d008ed9dd2