### PR TITLE
Fix duration calculation for segments

### DIFF
--- a/gpxutils.js
+++ b/gpxutils.js
@@ -87,8 +87,22 @@ function parseGpx(text) {
     }
     stats.distance_m = dist;
     perKm.forEach(km => {
-      if (km.start_time != null && km.end_time != null) {
-        km.duration_s = (km.end_time - km.start_time) / 1000;
+      let st = km.start_time;
+      let en = km.end_time;
+      if (km.start_idx != null && km.end_idx != null) {
+        if (st == null) {
+          for (let i = km.start_idx; i <= km.end_idx; i++) {
+            if (trackpoints[i][3] != null) { st = trackpoints[i][3]; break; }
+          }
+        }
+        if (en == null) {
+          for (let i = km.end_idx; i >= km.start_idx; i--) {
+            if (trackpoints[i][3] != null) { en = trackpoints[i][3]; break; }
+          }
+        }
+      }
+      if (st != null && en != null) {
+        km.duration_s = (en - st) / 1000;
       } else {
         km.duration_s = null;
       }
@@ -149,11 +163,11 @@ function analyzeSegments(stats) {
   }
 
   const ranges = [
-    { label: '[0%, 5%)', min: 0, max: 5, segs: [] },
-    { label: '[5%, 10%)', min: 5, max: 10, segs: [] },
-    { label: '[10%, 15%)', min: 10, max: 15, segs: [] },
-    { label: '[15%, 20%)', min: 15, max: 20, segs: [] },
-    { label: '[20%以上]', min: 20, max: Infinity, segs: [] }
+    { label: '[0%  -  5%]', min: 0, max: 5, segs: [] },
+    { label: '[5%  - 10%]', min: 5, max: 10, segs: [] },
+    { label: '[10% - 15%]', min: 10, max: 15, segs: [] },
+    { label: '[15% - 20%]', min: 15, max: 20, segs: [] },
+    { label: '[20% -    ]', min: 20, max: Infinity, segs: [] }
   ];
 
   segments.forEach(seg => {

--- a/test_gpxutils.js
+++ b/test_gpxutils.js
@@ -31,5 +31,6 @@ assert.strictEqual(stats.profile.length, stats.trackpoints.length);
 assert(stats.highest_elevation_m > 1000);
 assert(stats.lowest_elevation_m < 300);
 assert(Math.abs(stats.total_gain_m - stats.total_loss_m) < 1);
+assert(stats.per_km_elevation[0].duration_s > 0);
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- handle missing timestamp data when deriving per-km durations
- test duration calculation on GPX with trackpoint times

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686918b23d008331a6bc9c1e01424fef