### PR TITLE
Handle uphill/downhill segments

### DIFF
--- a/gpxutils.js
+++ b/gpxutils.js
@@ -184,15 +184,16 @@ function analyzeSegments(stats, interval = 500) {
   }
 
   const ranges = [
-    { label: '[0%  -  5%]', min: 0, max: 5, segs: [] },
-    { label: '[5%  - 10%]', min: 5, max: 10, segs: [] },
-    { label: '[10% - 15%]', min: 10, max: 15, segs: [] },
-    { label: '[15% - 20%]', min: 15, max: 20, segs: [] },
-    { label: '[20% -    ]', min: 20, max: Infinity, segs: [] }
+    { label: '[-40% -    ]', min: -Infinity, max: -40, segs: [] },
+    { label: '[-20% - -40%]', min: -40, max: -20, segs: [] },
+    { label: '[ -5% - -20%]', min: -20, max: -5, segs: [] },
+    { label: '[-5%  -   5%]', min: -5, max: 5, segs: [] },
+    { label: '[5%  -  20%]', min: 5, max: 20, segs: [] },
+    { label: '[20% -  40%]', min: 20, max: 40, segs: [] },
+    { label: '[40% -    ]', min: 40, max: Infinity, segs: [] }
   ];
 
   segments.forEach(seg => {
-    if (seg.net_rate < 0) return; // ignore downhill segments
     const grp = ranges.find(r => seg.net_rate >= r.min && seg.net_rate < r.max);
     if (grp) grp.segs.push(seg);
   });

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -369,11 +369,13 @@
     }
 
     const ranges = [
-      { label: '[0%  -  5%]', min: 0, max: 5 },
-      { label: '[5%  - 10%]', min: 5, max: 10 },
-      { label: '[10% - 15%]', min: 10, max: 15 },
-      { label: '[15% - 20%]', min: 15, max: 20 },
-      { label: '[20% -    ]', min: 20, max: Infinity }
+      { label: '[-40% -    ]', min: -Infinity, max: -40 },
+      { label: '[-20% - -40%]', min: -40, max: -20 },
+      { label: '[ -5% - -20%]', min: -20, max: -5 },
+      { label: '[-5%  -   5%]', min: -5, max: 5 },
+      { label: '[5%  -  20%]', min: 5, max: 20 },
+      { label: '[20% -  40%]', min: 20, max: 40 },
+      { label: '[40% -    ]', min: 40, max: Infinity }
     ];
     let waypoints = [];
     let wpMarkers = [];
@@ -397,7 +399,7 @@
 
     function predictedTimeSeconds(dist, netRate) {
       if (!predictedData || !predictedData.length) return null;
-      const slope = Math.max(0, netRate);
+      const slope = netRate;
       const range = ranges.find(r => slope >= r.min && slope < r.max);
       if (!range) return null;
       const grp = predictedData.find(g => g.label === range.label);


### PR DESCRIPTION
## Summary
- include downhill segments when summarizing rate groups
- expand rate groups to 7 categories covering downhill and uphill
- allow negative slopes when looking up predicted pace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693c8f140883318f9af94be2e5f5c5