### PR TITLE
Add responsive layout

### DIFF
--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -23,11 +23,11 @@
     }
     .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:100%; max-width:900px; }
     #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; justify-content:center; }
-    #left-panel { flex:0 0 auto; max-width:900px; }
+    #left-panel { flex:0 0 auto; max-width:540px; }
     #right-panel { flex:0 0 auto; max-width:1065px; }
     #layout h2 { margin:10px 0; }
-    #map { width:100%; max-width:900px; height:450px; }
-    #elevChart { width:100%; max-width:900px; height:auto; }
+    #map { width:100%; max-width:540px; height:450px; }
+    #elevChart { width:100%; max-width:540px; height:auto; }
     #perKmTable { width:100%; max-width:545px; height:980px; }
     #segmentTable, #predTable, #splitTimesTable { width:100%; max-width:510px; }
     .right-inner { display:flex; gap:10px; flex-wrap:wrap; }

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -22,8 +22,10 @@
       vertical-align: middle;
     }
     .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:100%; max-width:900px; }
-    #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; }
-    #left-panel, #right-panel { flex:1 1 500px; }
+    #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; justify-content:center; }
+    #left-panel { flex:0 0 auto; max-width:900px; }
+    #right-panel { flex:0 0 auto; max-width:1065px; }
+    #layout h2 { margin:10px 0; }
     #map { width:100%; max-width:900px; height:450px; }
     #elevChart { width:100%; max-width:900px; height:auto; }
     #perKmTable { width:100%; max-width:545px; height:980px; }

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -23,14 +23,14 @@
     }
     .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:100%; max-width:900px; }
     #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; justify-content:center; }
-    #left-panel { flex:0 0 auto; max-width:500px; }
-    #right-panel { flex:0 0 auto; max-width:810px; }
+    #left-panel { flex:0 0 500px; max-width:500px; }
+    #center-panel { flex:1 1 300px; max-width:400px; }
+    #right-panel { flex:1 1 300px; max-width:400px; }
     #layout h2 { margin:10px 0; }
     #map { width:100%; max-width:500px; height:450px; }
     #elevChart { width:100%; max-width:500px; height:auto; }
-    #perKmTable { width:100%; max-width:400px; height:980px; }
-    #segmentTable, #predTable, #splitTimesTable { width:100%; max-width:400px; }
-    .right-inner { display:flex; gap:10px; flex-wrap:wrap; }
+    #perKmTable { width:100%; height:980px; }
+    #segmentTable, #predTable, #splitTimesTable { width:100%; }
     .stats-col { flex:1; min-width:200px; line-height:1.2; }
     .stat-row { display:flex; justify-content:space-between; margin:2px 0; }
     .stat-label { flex:1; font-weight: bold; }
@@ -80,26 +80,22 @@
       </select>
       <canvas id="elevChart" width="500" height="450"></canvas>
     </div>
+    <div id="center-panel">
+      <h2>Elevation per KM</h2>
+      <div id="perKmTable" style="height:980px;"></div>
+    </div>
     <div id="right-panel">
-      <div class="right-inner">
-        <div>
-          <h2>Elevation per KM</h2>
-          <div id="perKmTable" style="height:980px;"></div>
-        </div>
-        <div>
-          <h2>Rate Groups</h2>
-          <div id="segmentTable"></div>
-          <button id="downloadRateBtn">Download JSON</button>
-          <h2 style="margin-top:20px;">Estimated Rate</h2>
-          <div id="predTable"></div>
-          <input type="file" id="rateFileInput" accept=".json" style="display:none">
-          <div style="margin-top:5px;display:flex;gap:5px;align-items:center;">
-            <button id="uploadRateBtn">Upload JSON</button>
-            <button id="refreshRateBtn">Refresh</button>
-          </div>
-          <div id="splitTimesTable" style="margin-top:10px;"></div>
-        </div>
+      <h2>Rate Groups</h2>
+      <div id="segmentTable"></div>
+      <button id="downloadRateBtn">Download JSON</button>
+      <h2 style="margin-top:20px;">Estimated Rate</h2>
+      <div id="predTable"></div>
+      <input type="file" id="rateFileInput" accept=".json" style="display:none">
+      <div style="margin-top:5px;display:flex;gap:5px;align-items:center;">
+        <button id="uploadRateBtn">Upload JSON</button>
+        <button id="refreshRateBtn">Refresh</button>
       </div>
+      <div id="splitTimesTable" style="margin-top:10px;"></div>
     </div>
   </div>
 

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -23,9 +23,9 @@
     }
     .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:100%; max-width:900px; }
     #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; justify-content:center; }
-    #left-panel { flex:0 0 500px; max-width:500px; }
-    #center-panel { flex:1 1 300px; max-width:400px; }
-    #right-panel { flex:1 1 300px; max-width:400px; }
+    #left-panel { flex:1 1 500px; max-width:500px; min-width:280px; }
+    #center-panel { flex:1 1 400px; max-width:400px; min-width:280px; }
+    #right-panel { flex:1 1 400px; max-width:400px; min-width:280px; }
     #layout h2 { margin:10px 0; }
     #map { width:100%; max-width:500px; height:450px; }
     #elevChart { width:100%; max-width:500px; height:auto; }

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -23,13 +23,13 @@
     }
     .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:100%; max-width:900px; }
     #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; justify-content:center; }
-    #left-panel { flex:0 0 auto; max-width:540px; }
-    #right-panel { flex:0 0 auto; max-width:1065px; }
+    #left-panel { flex:0 0 auto; max-width:500px; }
+    #right-panel { flex:0 0 auto; max-width:810px; }
     #layout h2 { margin:10px 0; }
-    #map { width:100%; max-width:540px; height:450px; }
-    #elevChart { width:100%; max-width:540px; height:auto; }
-    #perKmTable { width:100%; max-width:545px; height:980px; }
-    #segmentTable, #predTable, #splitTimesTable { width:100%; max-width:510px; }
+    #map { width:100%; max-width:500px; height:450px; }
+    #elevChart { width:100%; max-width:500px; height:auto; }
+    #perKmTable { width:100%; max-width:400px; height:980px; }
+    #segmentTable, #predTable, #splitTimesTable { width:100%; max-width:400px; }
     .right-inner { display:flex; gap:10px; flex-wrap:wrap; }
     .stats-col { flex:1; min-width:200px; line-height:1.2; }
     .stat-row { display:flex; justify-content:space-between; margin:2px 0; }
@@ -78,7 +78,7 @@
           <option value="<%= v %>" <%= v === initY ? 'selected' : '' %>><%= v %>m</option>
         <% } %>
       </select>
-      <canvas id="elevChart" width="900" height="450"></canvas>
+      <canvas id="elevChart" width="500" height="450"></canvas>
     </div>
     <div id="right-panel">
       <div class="right-inner">

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>GPX Result</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://unpkg.com/tabulator-tables@5.4.4/dist/css/tabulator.min.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
   <style>
@@ -20,7 +21,14 @@
       font-size: 1.4em;
       vertical-align: middle;
     }
-    .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:900px; }
+    .stats-grid { display:flex; gap:40px; flex-wrap:wrap; margin-bottom:10px; width:100%; max-width:900px; }
+    #layout { display:flex; align-items:flex-start; gap:10px; flex-wrap:wrap; }
+    #left-panel, #right-panel { flex:1 1 500px; }
+    #map { width:100%; max-width:900px; height:450px; }
+    #elevChart { width:100%; max-width:900px; height:auto; }
+    #perKmTable { width:100%; max-width:545px; height:980px; }
+    #segmentTable, #predTable, #splitTimesTable { width:100%; max-width:510px; }
+    .right-inner { display:flex; gap:10px; flex-wrap:wrap; }
     .stats-col { flex:1; min-width:200px; line-height:1.2; }
     .stat-row { display:flex; justify-content:space-between; margin:2px 0; }
     .stat-label { flex:1; font-weight: bold; }
@@ -56,10 +64,10 @@
       <div class="stat-row"><span class="stat-label">Total loss:</span><span class="stat-value"><%= stats.total_loss_m.toFixed(1) %> m</span></div>
     </div>
   </div>
-  <div id="layout" style="display:flex;align-items:flex-start;gap:10px;">
+  <div id="layout">
     <div id="left-panel">
       <h2>Track</h2>
-      <div id="map" style="width:900px;height:450px;border:1px solid #ccc"></div>
+      <div id="map" style="border:1px solid #ccc; height:450px;"></div>
       <h2>Elevation Profile</h2>
       <label for="yScale">Elevation Max:</label>
       <select id="yScale">
@@ -71,23 +79,23 @@
       <canvas id="elevChart" width="900" height="450"></canvas>
     </div>
     <div id="right-panel">
-      <div style="display:flex;gap:10px;">
+      <div class="right-inner">
         <div>
           <h2>Elevation per KM</h2>
-          <div id="perKmTable" style="width:545px;height:980px;"></div>
+          <div id="perKmTable" style="height:980px;"></div>
         </div>
         <div>
           <h2>Rate Groups</h2>
-          <div id="segmentTable" style="width:510px;"></div>
+          <div id="segmentTable"></div>
           <button id="downloadRateBtn">Download JSON</button>
           <h2 style="margin-top:20px;">Estimated Rate</h2>
-          <div id="predTable" style="width:510px;"></div>
+          <div id="predTable"></div>
           <input type="file" id="rateFileInput" accept=".json" style="display:none">
           <div style="margin-top:5px;display:flex;gap:5px;align-items:center;">
             <button id="uploadRateBtn">Upload JSON</button>
             <button id="refreshRateBtn">Refresh</button>
           </div>
-          <div id="splitTimesTable" style="width:510px;margin-top:10px;"></div>
+          <div id="splitTimesTable" style="margin-top:10px;"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add viewport meta tag
- update `result.ejs` styles for responsive layout
- remove inline widths in favor of flexible CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686941fe69f8833185cb8c1dd5b3ec74