### PR TITLE
Display GPX waypoints on map

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Simple Node.js and Express application to upload a GPX file and show basic statistics.
 The uploaded track is displayed on a Google Map and an elevation profile is rendered using Chart.js loaded from a CDN. Moving the mouse over either element highlights the corresponding position in the other.
 It draws the track and an elevation profile using Chart.js loaded from a CDN.
+Waypoints contained in the GPX file are automatically displayed on the map and on the elevation chart.
 
 ## Usage
 

--- a/gpxutils.js
+++ b/gpxutils.js
@@ -51,6 +51,27 @@ function extractTrackpoints(text) {
   };
 }
 
+function extractWaypoints(text) {
+  const waypoints = [];
+  const regex = /<wpt\b([^>]*)(?:\/>|>([\s\S]*?)<\/wpt>)/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const attrs = match[1];
+    const content = match[2] || "";
+    const latMatch = /lat="([^"]+)"/.exec(attrs);
+    const lonMatch = /lon="([^"]+)"/.exec(attrs);
+    if (!latMatch || !lonMatch) continue;
+    const wp = {
+      lat: parseFloat(latMatch[1]),
+      lon: parseFloat(lonMatch[1]),
+    };
+    const nameMatch = /<name>([^<]+)<\/name>/i.exec(content);
+    if (nameMatch) wp.name = nameMatch[1];
+    waypoints.push(wp);
+  }
+  return waypoints;
+}
+
 function calcPerKmStats(trackpoints, step = 100) {
   let dist = 0;
   const perKm = [];
@@ -134,6 +155,7 @@ function calcPerKmStats(trackpoints, step = 100) {
 
 function parseGpx(text) {
   const { trackpoints, highest, lowest } = extractTrackpoints(text);
+  const waypoints = extractWaypoints(text);
   const stats = { points: trackpoints.length };
   if (trackpoints.length > 0) {
     const lats = trackpoints.map((p) => p[0]);
@@ -157,6 +179,7 @@ function parseGpx(text) {
   stats.highest_elevation_m = highest;
   stats.lowest_elevation_m = lowest;
   stats.trackpoints = trackpoints;
+  stats.waypoints = waypoints;
   return stats;
 }
 

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -137,6 +137,7 @@
     const perKmData = <%- JSON.stringify(stats.per_km_elevation || []) %>;
     const segmentData = <%- JSON.stringify(segmentSummary || {}) %>;
     const predictedData = JSON.parse(JSON.stringify(segmentData.summary || []));
+    const gpxWaypoints = <%- JSON.stringify(stats.waypoints || []) %>;
 
     function addTrendInfo(arr) {
       arr.forEach(row => {
@@ -560,6 +561,13 @@
       chart.update();
     }
 
+    function loadPredefinedWaypoints() {
+      gpxWaypoints.forEach(wp => {
+        const idx = nearestIndex(wp.lat, wp.lon);
+        addWaypoint(idx);
+      });
+    }
+
     function addWaypoint(idx) {
       if (idx <= 0 || idx >= points.length - 1) return;
       if (!waypoints.includes(idx)) {
@@ -586,6 +594,7 @@
     createMap();
     initChart();
     initTable();
+    loadPredefinedWaypoints();
     updateSegments();
     updateWaypointDataset();
   };
@@ -639,6 +648,9 @@
   document.addEventListener('DOMContentLoaded', function() {
     initChart();
     initTable();
+    loadPredefinedWaypoints();
+    updateSegments();
+    updateWaypointDataset();
   });
 </script>
 <% } %>

--- a/test_gpxutils.js
+++ b/test_gpxutils.js
@@ -33,4 +33,10 @@ assert(stats.lowest_elevation_m < 300);
 assert(Math.abs(stats.total_gain_m - stats.total_loss_m) < 1);
 assert(stats.per_km_elevation[0].duration_s > 0);
 
+data = fs.readFileSync("testdata/sample_wp.gpx", "utf8");
+stats = parseGpx(data);
+assert.strictEqual(stats.waypoints.length, 2);
+assert.strictEqual(stats.waypoints[0].name, "WP1");
+assert.strictEqual(stats.waypoints[1].name, "WP2");
+
 console.log("All tests passed");

--- a/testdata/sample_wp.gpx
+++ b/testdata/sample_wp.gpx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="35.0" lon="135.011"><name>WP1</name></wpt>
+  <wpt lat="35.0" lon="135.033"><name>WP2</name></wpt>
+  <trk>
+    <name>Example GPX with WPT</name>
+    <trkseg>
+      <trkpt lat="35.0" lon="135.000"><ele>100</ele></trkpt>
+      <trkpt lat="35.0" lon="135.011"><ele>110</ele></trkpt>
+      <trkpt lat="35.0" lon="135.022"><ele>105</ele></trkpt>
+      <trkpt lat="35.0" lon="135.033"><ele>115</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>


### PR DESCRIPTION
## Summary
- parse `<wpt>` elements from uploaded GPX
- expose parsed waypoints to the results page
- automatically add parsed waypoints to the map and elevation chart
- add simple GPX with waypoints for tests
- update tests and docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869fcbb45508331af580f212763403c