### PR TITLE
Add GPT text analysis button

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Waypoints contained in the GPX file are automatically displayed on the map and o
 4. Open `http://localhost:8180` in your browser. Drop a `.gpx` file onto the page
    or use the file picker at the top to upload it. The page then displays various
    statistics and provides a button to download the JSON summary.
+5. (Optional) To generate a textual analysis of the uploaded track using GPT,
+   set `OPENAI_API_KEY` in the environment. A "Generate Text Report" button
+   appears on the result page and will call the OpenAI API to create a short
+   report describing the run.
 
 ### Command line analysis
 

--- a/app.js
+++ b/app.js
@@ -4,7 +4,45 @@ const multer = require("multer");
 const path = require("path");
 const { parseGpx, analyzeSegments } = require("./gpxutils.js");
 
+function augmentStats(stats) {
+  if (stats.trackpoints && stats.trackpoints.length > 1) {
+    const times = stats.trackpoints
+      .map((p) => p[3])
+      .filter((t) => t != null);
+    if (times.length >= 2) {
+      const start = times[0];
+      const end = times[times.length - 1];
+      stats.total_time_s = (end - start) / 1000;
+      if (stats.distance_m) {
+        stats.avg_pace_min_per_km =
+          (stats.total_time_s / 60) / (stats.distance_m / 1000);
+      }
+    }
+  }
+  return stats;
+}
+
+function buildPrompt(stats) {
+  return `あなたは優秀なトレイルランニングコーチ兼アナリストです。以下のGPXデータを分析し、事実に基づく具体的な説明を文章で伝えてください。表やグラフは不要です。
+
+【求める内容】
+- 総距離、累積標高、平均ペース、総時間、最高高度、最低高度などの基本情報を文章で説明
+- 区間ごとのペースや標高変化について文章で言及（例：「後半の急登区間ではペースが6分/km台に落ち込んでいます」など）
+- 上りと下りでの走りの特徴やペースの違いを事実に基づき解説
+- ペース変動の背景（疲労、坂、気温など）を推察し、文章で述べる
+- 改善点や次回の戦略を具体的に提案
+
+【表現の指針】
+- 数字は使ってよい（例：「累積標高は1,800mです」）
+- 表やグラフなどの視覚的な要素は使わない
+- 客観的かつわかりやすい文章で、選手に伝えるレポートのようにまとめる
+
+GPX統計データ: ${JSON.stringify(stats)}
+`;
+}
+
 const app = express();
+app.use(express.json({ limit: "5mb" }));
 const upload = multer();
 
 app.set("view engine", "ejs");
@@ -33,10 +71,36 @@ app.post("/upload", upload.single("gpxfile"), async (req, res) => {
       process.env.GOOGLE_MAPS_API_KEY ||
       process.env.GOOGLEMAPS_API_KEY ||
       process.env.GOOGLE_MAP_API_KEY;
-    console.log("apikei:" + apiKey);
     res.render("result", { stats, googleMapsApiKey: apiKey, segmentSummary });
   } catch (err) {
     res.status(400).send("Failed to parse GPX");
+  }
+});
+
+app.post("/generate-analysis", async (req, res) => {
+  const stats = req.body.stats;
+  if (!stats) return res.status(400).json({ error: "Missing stats" });
+  augmentStats(stats);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) return res.status(500).json({ error: "OpenAI API key not configured" });
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-3.5-turbo",
+        messages: [{ role: "user", content: buildPrompt(stats) }],
+      }),
+    });
+    const data = await response.json();
+    const text = data.choices && data.choices[0]?.message?.content;
+    res.json({ text });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to fetch analysis" });
   }
 });
 

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -93,6 +93,10 @@
       <div class="stat-row"><span class="stat-label">Total loss:</span><span class="stat-value"><%= stats.total_loss_m.toFixed(1) %> m</span></div>
     </div>
   </div>
+  <div style="margin:10px 0;">
+    <button id="generateAnalysisBtn">Generate Text Report</button>
+    <div id="analysisResult" style="white-space:pre-wrap;margin-top:10px;"></div>
+  </div>
   <div id="layout">
     <div id="left-panel">
       <h2>Track</h2>
@@ -138,6 +142,7 @@
     const segmentData = <%- JSON.stringify(segmentSummary || {}) %>;
     const predictedData = JSON.parse(JSON.stringify(segmentData.summary || []));
     const gpxWaypoints = <%- JSON.stringify(stats.waypoints || []) %>;
+    const statsData = <%- JSON.stringify(stats) %>;
 
     function addTrendInfo(arr) {
       arr.forEach(row => {
@@ -637,6 +642,23 @@
 
   document.getElementById('refreshRateBtn').addEventListener('click', function() {
     computePredictedTimes();
+  });
+
+  document.getElementById('generateAnalysisBtn').addEventListener('click', function() {
+    const resultEl = document.getElementById('analysisResult');
+    resultEl.textContent = 'Generating...';
+    fetch('/generate-analysis', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stats: statsData })
+    })
+      .then(res => res.json())
+      .then(data => {
+        resultEl.textContent = data.text || 'Failed to generate';
+      })
+      .catch(() => {
+        resultEl.textContent = 'Error generating analysis';
+      });
   });
 
 </script>


### PR DESCRIPTION
## Summary
- compute total time and average pace in app
- create GPT prompt helper
- add `/generate-analysis` route
- show new Generate Text Report button in results page
- send stats to backend and render returned analysis text
- show loading text while waiting for analysis
- document optional `OPENAI_API_KEY`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6869ff96406c83319910562198389428