### PR TITLE
Summarize stats before sending to GPT

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ require("dotenv").config();
 const express = require("express");
 const multer = require("multer");
 const path = require("path");
-const { parseGpx, analyzeSegments } = require("./gpxutils.js");
+const { parseGpx, summarizeStats, analyzeSegments } = require("./gpxutils.js");
 
 function augmentStats(stats) {
   if (stats.trackpoints && stats.trackpoints.length > 1) {
@@ -22,7 +22,7 @@ function augmentStats(stats) {
   return stats;
 }
 
-function buildPrompt(stats) {
+function buildPrompt(summary) {
   return `あなたは優秀なトレイルランニングコーチ兼アナリストです。以下のGPXデータを分析し、事実に基づく具体的な説明を文章で伝えてください。表やグラフは不要です。
 
 【求める内容】
@@ -37,7 +37,7 @@ function buildPrompt(stats) {
 - 表やグラフなどの視覚的な要素は使わない
 - 客観的かつわかりやすい文章で、選手に伝えるレポートのようにまとめる
 
-GPX統計データ: ${JSON.stringify(stats)}
+GPX統計データ: ${JSON.stringify(summary)}
 `;
 }
 
@@ -92,7 +92,7 @@ app.post("/generate-analysis", async (req, res) => {
       },
       body: JSON.stringify({
         model: "gpt-3.5-turbo",
-        messages: [{ role: "user", content: buildPrompt(stats) }],
+        messages: [{ role: "user", content: buildPrompt(summarizeStats(stats)) }],
       }),
     });
     const data = await response.json();

--- a/test_gpxutils.js
+++ b/test_gpxutils.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const assert = require("assert");
-const { parseGpx } = require("./gpxutils.js");
+const { parseGpx, summarizeStats } = require("./gpxutils.js");
 
 let data = fs.readFileSync("testdata/sample.gpx", "utf8");
 let stats = parseGpx(data);
@@ -32,6 +32,11 @@ assert(stats.highest_elevation_m > 1000);
 assert(stats.lowest_elevation_m < 300);
 assert(Math.abs(stats.total_gain_m - stats.total_loss_m) < 1);
 assert(stats.per_km_elevation[0].duration_s > 0);
+
+const summary = summarizeStats(stats);
+assert(summary.total_distance_km > 50);
+assert.strictEqual(summary.pace_per_km.length, stats.per_km_elevation.length);
+assert(summary.max_pace_min_per_km <= summary.min_pace_min_per_km);
 
 data = fs.readFileSync("testdata/sample_wp.gpx", "utf8");
 stats = parseGpx(data);


### PR DESCRIPTION
## Summary
- add `summarizeStats` helper to compute condensed metrics from parsed GPX
- send this summary to OpenAI instead of the full GPX stats
- expose `summarizeStats` from `gpxutils`
- test the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bba303d3c833196276df140778fd6