### PR TITLE
Enhance trend categories and analysis display

### DIFF
--- a/gpxutils.js
+++ b/gpxutils.js
@@ -211,17 +211,19 @@ function analyzeSlopeTime(stats, upThreshold, downThreshold) {
 function analyzeSegments(stats, interval = 500) {
   const { perKm } = calcPerKmStats(stats.trackpoints, interval);
   const segments = [];
-  for (let i = 0; i < perKm.length; i++) {
+  const numSegs = Math.ceil(stats.distance_m / interval);
+  for (let i = 0; i < numSegs; i++) {
+    const kmData = perKm[i] || {};
     const segDist =
-      i === perKm.length - 1
+      i === numSegs - 1
         ? Math.max(0, stats.distance_m - i * interval)
         : interval;
-    const gain = perKm[i].gain;
-    const loss = perKm[i].loss;
+    const gain = kmData.gain || 0;
+    const loss = kmData.loss || 0;
     const upRate = segDist > 0 ? (gain / segDist) * 100 : 0;
     const downRate = segDist > 0 ? (loss / segDist) * 100 : 0;
     const netRate = upRate - downRate;
-    const duration = perKm[i].duration_s;
+    const duration = kmData.duration_s;
     const pace =
       duration && segDist > 0 ? duration / 60 / (segDist / 1000) : null;
     segments.push({
@@ -238,13 +240,19 @@ function analyzeSegments(stats, interval = 500) {
   }
 
   const ranges = [
-    { label: "[-40% -    ]", min: -Infinity, max: -40, segs: [] },
-    { label: "[-20% - -40%]", min: -40, max: -20, segs: [] },
-    { label: "[ -5% - -20%]", min: -20, max: -5, segs: [] },
+    { label: "[-50% -    ]", min: -Infinity, max: -50, segs: [] },
+    { label: "[-40% - -50%]", min: -50, max: -40, segs: [] },
+    { label: "[-30% - -40%]", min: -40, max: -30, segs: [] },
+    { label: "[-20% - -30%]", min: -30, max: -20, segs: [] },
+    { label: "[-10% - -20%]", min: -20, max: -10, segs: [] },
+    { label: "[ -5% - -10%]", min: -10, max: -5, segs: [] },
     { label: "[-5%  -   5%]", min: -5, max: 5, segs: [] },
-    { label: "[5%  -  20%]", min: 5, max: 20, segs: [] },
-    { label: "[20% -  40%]", min: 20, max: 40, segs: [] },
-    { label: "[40% -    ]", min: 40, max: Infinity, segs: [] },
+    { label: "[5%  -  10%]", min: 5, max: 10, segs: [] },
+    { label: "[10% -  20%]", min: 10, max: 20, segs: [] },
+    { label: "[20% -  30%]", min: 20, max: 30, segs: [] },
+    { label: "[30% -  40%]", min: 30, max: 40, segs: [] },
+    { label: "[40% -  50%]", min: 40, max: 50, segs: [] },
+    { label: "[50% -    ]", min: 50, max: Infinity, segs: [] },
   ];
 
   segments.forEach((seg) => {

--- a/templates/result.ejs
+++ b/templates/result.ejs
@@ -10,9 +10,13 @@
     .up1 { color: #6bc56b; }
     .up2 { color: #2e8b57; }
     .up3 { color: #006400; }
+    .up4 { color: #004b00; }
+    .up5 { color: #002b00; }
     .down1 { color: #e9967a; }
     .down2 { color: #cd5c5c; }
     .down3 { color: #8b0000; }
+    .down4 { color: #7a0000; }
+    .down5 { color: #3f0000; }
     .flat { color: #808080; }
     .material-symbols-outlined {
       font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24;
@@ -95,7 +99,7 @@
   </div>
   <div style="margin:10px 0;">
     <button id="generateAnalysisBtn">Generate Text Report</button>
-    <div id="analysisResult" style="white-space:pre-wrap;margin-top:10px;"></div>
+    <div id="analysisResult" style="white-space:pre-wrap;margin-top:10px;max-width:700px;margin-left:auto;margin-right:auto;padding:10px;border:1px solid #ccc;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.2);"></div>
   </div>
   <div id="layout">
     <div id="left-panel">
@@ -148,14 +152,18 @@
       arr.forEach(row => {
         const diff = (row.gain && row.loss) != null ? (row.gain - row.loss) : row.avg_net_rate;
         let icon, cls;
-        if (diff > 5) {
+        if (diff > 10) {
           icon = 'trending_up';
-          if (diff > 40) cls = 'up3';
+          if (diff > 50) cls = 'up5';
+          else if (diff > 40) cls = 'up4';
+          else if (diff > 30) cls = 'up3';
           else if (diff > 20) cls = 'up2';
           else cls = 'up1';
-        } else if (diff < -5) {
+        } else if (diff < -10) {
           icon = 'trending_down';
-          if (diff < -40) cls = 'down3';
+          if (diff < -50) cls = 'down5';
+          else if (diff < -40) cls = 'down4';
+          else if (diff < -30) cls = 'down3';
           else if (diff < -20) cls = 'down2';
           else cls = 'down1';
         } else {
@@ -172,6 +180,7 @@
   </script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://unpkg.com/tabulator-tables@5.4.4/dist/js/tabulator.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script>
     let chart, map, marker, rangePolyline;
     const hoverLine = {
@@ -408,13 +417,19 @@
     }
 
     const ranges = [
-      { label: '[-40% -    ]', min: -Infinity, max: -40 },
-      { label: '[-20% - -40%]', min: -40, max: -20 },
-      { label: '[ -5% - -20%]', min: -20, max: -5 },
+      { label: '[-50% -    ]', min: -Infinity, max: -50 },
+      { label: '[-40% - -50%]', min: -50, max: -40 },
+      { label: '[-30% - -40%]', min: -40, max: -30 },
+      { label: '[-20% - -30%]', min: -30, max: -20 },
+      { label: '[-10% - -20%]', min: -20, max: -10 },
+      { label: '[ -5% - -10%]', min: -10, max: -5 },
       { label: '[-5%  -   5%]', min: -5, max: 5 },
-      { label: '[5%  -  20%]', min: 5, max: 20 },
-      { label: '[20% -  40%]', min: 20, max: 40 },
-      { label: '[40% -    ]', min: 40, max: Infinity }
+      { label: '[5%  -  10%]', min: 5, max: 10 },
+      { label: '[10% -  20%]', min: 10, max: 20 },
+      { label: '[20% -  30%]', min: 20, max: 30 },
+      { label: '[30% -  40%]', min: 30, max: 40 },
+      { label: '[40% -  50%]', min: 40, max: 50 },
+      { label: '[50% -    ]', min: 50, max: Infinity }
     ];
     let waypoints = [];
     let wpMarkers = [];
@@ -654,7 +669,11 @@
     })
       .then(res => res.json())
       .then(data => {
-        resultEl.textContent = data.text || 'Failed to generate';
+        if (data.text) {
+          resultEl.innerHTML = marked.parse(data.text);
+        } else {
+          resultEl.textContent = 'Failed to generate';
+        }
       })
       .catch(() => {
         resultEl.textContent = 'Error generating analysis';


### PR DESCRIPTION
## Summary
- refine slope ranges used for rate groups
- add additional trend color levels and thresholds
- format analysis result markdown with HTML container
- keep predicted segments robust when data is sparse

## Testing
- `npm test`
- `node segment_analysis.js testdata/sample.gpx | head`

------
https://chatgpt.com/codex/tasks/task_e_686bc2e429548331ba70168c52fe3974