### PR TITLE
Add basic Vue interface

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,10 @@ app.get("/", (req, res) => {
   });
 });
 
+app.get("/vue", (req, res) => {
+  res.render("vue");
+});
+
 app.post("/upload", upload.single("gpxfile"), async (req, res) => {
   if (!req.file) {
     return res.status(400).send("No file uploaded");
@@ -75,6 +79,19 @@ app.post("/upload", upload.single("gpxfile"), async (req, res) => {
     res.render("result", { stats, googleMapsApiKey: apiKey, segmentSummary });
   } catch (err) {
     res.status(400).send("Failed to parse GPX");
+  }
+});
+
+app.post("/api/upload", upload.single("gpxfile"), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: "No file" });
+  }
+  try {
+    const stats = parseGpx(req.file.buffer.toString());
+    const segmentSummary = analyzeSegments(stats);
+    res.json({ stats, segmentSummary });
+  } catch (err) {
+    res.status(400).json({ error: "Failed to parse" });
   }
 });
 

--- a/templates/vue.ejs
+++ b/templates/vue.ejs
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>GPX Viewer - Vue</title>
+  <script src="https://unpkg.com/vue@3"></script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <h1>GPX Viewer (Vue)</h1>
+    <input type="file" @change="upload" accept=".gpx">
+    <div v-if="stats">
+      <h2>Summary</h2>
+      <ul>
+        <li>Total distance: {{ stats.total_distance_km }} km</li>
+        <li>Total gain: {{ stats.total_gain_m }} m</li>
+        <li>Total loss: {{ stats.total_loss_m }} m</li>
+        <li>Highest elevation: {{ stats.highest_elevation_m }} m</li>
+        <li>Lowest elevation: {{ stats.lowest_elevation_m }} m</li>
+      </ul>
+    </div>
+  </div>
+<script>
+const { createApp } = Vue;
+createApp({
+  data() {
+    return { stats: null };
+  },
+  methods: {
+    upload(e) {
+      const file = e.target.files[0];
+      if (!file) return;
+      const formData = new FormData();
+      formData.append('gpxfile', file);
+      fetch('/api/upload', { method: 'POST', body: formData })
+        .then(res => res.json())
+        .then(data => { this.stats = data.stats; })
+        .catch(() => { alert('Failed to parse GPX'); });
+    }
+  }
+}).mount('#app');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple /vue page rendered with Vue 3
- expose /api/upload to return stats as JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d3290d830833192a89d08d5d91c58