### PR TITLE
Fix Vuetify stats tab layout

### DIFF
--- a/templates/vuetify.ejs
+++ b/templates/vuetify.ejs
@@ -48,17 +48,18 @@
             <v-tab value="0">統計情報・予測</v-tab>
             <v-tab value="1">地図・高低差</v-tab>
           </v-tabs>
-          <v-tabs-window v-model="tab">
-            <v-tab-item value="0" class="mt-4">
+          <v-window v-model="tab">
+            <v-window-item value="0" class="mt-4">
               <v-data-table :items="perKmData" :headers="perKmHeaders" class="mb-4" density="compact"></v-data-table>
               <v-data-table :items="summaryGroups" :headers="rateHeaders" class="mb-4" density="compact"></v-data-table>
-              <v-data-table :items="rateGroups" :headers="segmentHeaders" density="compact"></v-data-table>
-            </v-tab-item>
-            <v-tab-item value="1" class="mt-4">
+              <v-data-table :items="rateGroups" :headers="segmentHeaders" class="mb-4" density="compact"></v-data-table>
+              <v-data-table :items="predictedData" :headers="rateHeaders" density="compact"></v-data-table>
+            </v-window-item>
+            <v-window-item value="1" class="mt-4">
               <div id="map" class="mb-4"></div>
               <canvas id="chart"></canvas>
-            </v-tab-item>
-          </v-tabs-window>
+            </v-window-item>
+          </v-window>
         </div>
       </v-container>
     </v-main>
@@ -73,6 +74,7 @@ createApp({
       file: null,
       stats: {},
       segmentSummary: null,
+      predictedData: [],
       uploaderPanel: 0,
       tab: 0
     };
@@ -125,6 +127,7 @@ createApp({
         .then(data => {
           this.stats = data.stats;
           this.segmentSummary = data.segmentSummary;
+          this.predictedData = JSON.parse(JSON.stringify(data.segmentSummary.summary || []));
           this.$nextTick(() => { this.initMap(); this.initChart(); });
           this.uploaderPanel = null;
         })


### PR DESCRIPTION
## Summary
- fix tab window components so map only appears in map tab
- include estimated rate table on stats tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d45d9863c8331972f4491282595b8