### PR TITLE
Add waypoint feature to Vuetify UI

### DIFF
--- a/templates/vuetify.ejs
+++ b/templates/vuetify.ejs
@@ -152,6 +152,10 @@
             <v-window-item :value="1" class="mt-4">
               <div id="map" class="mb-4"></div>
               <canvas id="chart"></canvas>
+              <div class="mt-4">
+                <v-btn size="small" class="mb-2" @click="clearWaypoints">Clear Waypoints</v-btn>
+                <div id="waypointStats"></div>
+              </div>
             </v-window-item>
           </v-window>
         </div>
@@ -213,6 +217,8 @@ createApp({
       chart: null,
       marker: null,
       rangePolyline: null,
+      waypoints: [],
+      wpMarkers: [],
       ranges: [
         { label: '[-50% -    ]', min: -Infinity, max: -50 },
         { label: '[-40% - -50%]', min: -50, max: -40 },
@@ -285,6 +291,9 @@ createApp({
         this.$nextTick(() => {
           this.initMap();
           this.initChart();
+          this.loadPredefinedWaypoints();
+          this.updateSegments();
+          this.updateWaypointDataset();
         });
       }
     },
@@ -325,7 +334,16 @@ createApp({
           if (this.segmentSummary && this.segmentSummary.summary) this.addTrendInfo(this.segmentSummary.summary);
           this.addTrendInfo(this.predictedData);
           this.computePredictedTimes();
-          this.$nextTick(() => { this.initMap(); this.initChart(); });
+          this.waypoints = [];
+          this.wpMarkers.forEach(m => m.setMap(null));
+          this.wpMarkers = [];
+          this.$nextTick(() => {
+            this.initMap();
+            this.initChart();
+            this.loadPredefinedWaypoints();
+            this.updateSegments();
+            this.updateWaypointDataset();
+          });
           this.uploaderPanel = null;
         })
         .catch(() => alert('Failed to parse GPX'));
@@ -372,6 +390,14 @@ createApp({
         const idx = this.nearestIndex(e.latLng.lat(), e.latLng.lng());
         this.updateHighlight(idx);
       });
+      this.map.addListener('click', e => {
+        const idx = this.nearestIndex(e.latLng.lat(), e.latLng.lng());
+        this.addWaypoint(idx);
+      });
+      poly.addListener('click', e => {
+        const idx = this.nearestIndex(e.latLng.lat(), e.latLng.lng());
+        this.addWaypoint(idx);
+      });
       if (this.stats.waypoints) {
         this.stats.waypoints.forEach(wp => {
           new google.maps.Marker({ position: { lat: wp.lat, lng: wp.lon }, map: this.map, title: wp.name || '' });
@@ -398,6 +424,10 @@ createApp({
       document.getElementById('chart').addEventListener('mousemove', evt => {
         const els = this.chart.getElementsAtEventForMode(evt, 'nearest', { intersect: false }, false);
         if (els.length) this.updateHighlight(els[0].index);
+      });
+      document.getElementById('chart').addEventListener('click', evt => {
+        const els = this.chart.getElementsAtEventForMode(evt, 'nearest', { intersect: false }, false);
+        if (els.length) this.addWaypoint(els[0].index);
       });
     },
     formatTime(sec) {
@@ -512,6 +542,98 @@ createApp({
           this.rangePolyline.setMap(this.map);
         }
       }
+    },
+    computeStats(startIdx, endIdx) {
+      if (endIdx <= startIdx) return null;
+      const pts = this.stats.trackpoints;
+      const dist = pts[endIdx][4] - pts[startIdx][4];
+      let gain = 0, loss = 0;
+      for (let i = startIdx + 1; i <= endIdx; i++) {
+        const diff = pts[i][2] - pts[i-1][2];
+        if (diff > 0) gain += diff; else if (diff < 0) loss += -diff;
+      }
+      const avgUp = dist > 0 ? (gain / dist) * 100 : 0;
+      const avgDown = dist > 0 ? (loss / dist) * 100 : 0;
+      const netRate = avgUp - avgDown;
+      const pred = this.formatTime(this.predictedTimeSeconds(dist, netRate));
+      return { dist_m: dist, gain_m: gain, loss_m: loss, avg_up: avgUp, avg_down: avgDown, pred_time: pred };
+    },
+    buildWaypointSegments() {
+      const idxs = [0, ...this.waypoints, this.stats.trackpoints.length - 1].sort((a,b) => a - b);
+      const segs = [];
+      for (let i = 0; i < idxs.length - 1; i++) {
+        const stats = this.computeStats(idxs[i], idxs[i+1]);
+        if (stats) segs.push(Object.assign({ idx: i + 1 }, stats));
+      }
+      return segs;
+    },
+    updateSegments() {
+      const segs = this.buildWaypointSegments();
+      const container = document.getElementById('waypointStats');
+      if (!container) return;
+      container.innerHTML = '';
+      const table = document.createElement('table');
+      const thead = document.createElement('thead');
+      const headRow = document.createElement('tr');
+      headRow.innerHTML = '<th class="label-cell">Name</th>';
+      segs.forEach((seg, i) => {
+        const startLabel = i === 0 ? 'Start' : `WP${i}`;
+        const endLabel = i === segs.length - 1 ? 'Finish' : `WP${i+1}`;
+        headRow.innerHTML += `<th>${startLabel}-${endLabel}</th>`;
+      });
+      thead.appendChild(headRow);
+      table.appendChild(thead);
+      const tbody = document.createElement('tbody');
+      const rows = [
+        { label: 'Distance', format: seg => `${(seg.dist_m/1000).toFixed(1)} km` },
+        { label: 'Elevation Gain', format: seg => `${seg.gain_m.toFixed(1)} m` },
+        { label: 'Elevation Loss', format: seg => `${seg.loss_m.toFixed(1)} m` },
+        { label: 'Average Up', format: seg => `${seg.avg_up.toFixed(2)} %` },
+        { label: 'Average Down', format: seg => `${seg.avg_down.toFixed(2)} %` }
+      ];
+      rows.forEach(info => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td class="label-cell">${info.label}</td>` + segs.map(seg => `<td>${info.format(seg)}</td>`).join('');
+        tbody.appendChild(row);
+      });
+      table.appendChild(tbody);
+      container.appendChild(table);
+    },
+    updateWaypointDataset() {
+      if (!this.chart || !this.stats.profile) return;
+      const data = this.stats.profile.map((p, idx) => this.waypoints.includes(idx) ? p[1] : null);
+      if (this.chart.data.datasets.length === 1) {
+        this.chart.data.datasets.push({ label: 'Waypoints', data, borderColor: 'red', backgroundColor: 'red', showLine: false, pointRadius: 4 });
+      } else {
+        this.chart.data.datasets[1].data = data;
+      }
+      this.chart.update();
+    },
+    loadPredefinedWaypoints() {
+      (this.stats.waypoints || []).forEach(wp => {
+        const idx = this.nearestIndex(wp.lat, wp.lon);
+        this.addWaypoint(idx);
+      });
+    },
+    addWaypoint(idx) {
+      if (idx <= 0 || idx >= this.stats.trackpoints.length - 1) return;
+      if (!this.waypoints.includes(idx)) {
+        this.waypoints.push(idx);
+        this.waypoints.sort((a,b) => a-b);
+        if (this.map) {
+          const marker = new google.maps.Marker({ position: { lat: this.stats.trackpoints[idx][0], lng: this.stats.trackpoints[idx][1] }, map: this.map, label: String(this.waypoints.indexOf(idx)+1) });
+          this.wpMarkers.push(marker);
+        }
+        this.updateSegments();
+        this.updateWaypointDataset();
+      }
+    },
+    clearWaypoints() {
+      this.waypoints = [];
+      this.wpMarkers.forEach(m => m.setMap(null));
+      this.wpMarkers = [];
+      this.updateSegments();
+      this.updateWaypointDataset();
     },
     onKmRowClick(_e, row) {
       if (row.start_idx != null && row.end_idx != null) {


### PR DESCRIPTION
## Summary
- enable waypoint markers in `vuetify.ejs`
- allow map and chart clicks to add waypoints
- show waypoint segment statistics below the chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0fa110fc8331bdbc7752b847d0a2