### PR TITLE
Fix slope trend icons for empty groups

### DIFF
--- a/templates/vuetify.ejs
+++ b/templates/vuetify.ejs
@@ -566,7 +566,19 @@ createApp({
     addTrendInfo(arr) {
       if (!arr) return;
       arr.forEach(row => {
-        const diff = (row.gain != null && row.loss != null) ? (row.gain - row.loss) : row.avg_net_rate;
+        let diff;
+        if (row.gain != null && row.loss != null) {
+          diff = row.gain - row.loss;
+        } else if (row.avg_net_rate != null) {
+          diff = row.avg_net_rate;
+        } else {
+          const r = this.ranges.find(v => v.label === row.label);
+          if (r) {
+            if (r.max <= -5) diff = -11;
+            else if (r.min >= 5) diff = 11;
+            else diff = 0;
+          }
+        }
         let icon, cls;
         if (diff > 10) {
           icon = 'trending_up';


### PR DESCRIPTION
## Summary
- show proper up/down icons for summary rows even when there is no data

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686e48d2dc188331bafee32d3b172359