### PR TITLE
Add mobile viewport to templates

### DIFF
--- a/templates/vue.ejs
+++ b/templates/vue.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>GPX Viewer - Vue</title>
   <script src="https://unpkg.com/vue@3"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>

--- a/templates/vuetify.ejs
+++ b/templates/vuetify.ejs
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>GPX Vuetify</title>
   <link href="https://cdn.jsdelivr.net/npm/vuetify@3.3.6/dist/vuetify.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/@mdi/font@7.x/css/materialdesignicons.min.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- ensure mobile-friendly scaling
- add viewport metadata for base Vue and Vuetify templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e51d5f5b88331a3d59ad27fb7ce76