### PR TITLE
Increase map color segmentation granularity

### DIFF
--- a/frontend/templates/vuetify.ejs
+++ b/frontend/templates/vuetify.ejs
@@ -600,7 +600,8 @@ createApp({
       this.map.fitBounds(bounds);
       // Group multiple points into a single colored segment to avoid creating
       // thousands of individual polylines which can slow down rendering.
-      const step = 20; // number of points per segment
+      // Use smaller segments so the color changes are more fine grained
+      const step = 10; // number of points per segment
       const segments = [];
       for (let i = 0; i < this.stats.trackpoints.length - 1; i += step) {
         const startIdx = i;


### PR DESCRIPTION
## Summary
- adjust map polyline rendering to split trackpoints into smaller segments

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6870f0ef95ec8331befe68773ab70f65