### PR TITLE
Implement smooth scroll to tab section

### DIFF
--- a/frontend/templates/vuetify.ejs
+++ b/frontend/templates/vuetify.ejs
@@ -441,7 +441,7 @@ createApp({
   },
   watch: {
     tab(val) {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      this.scrollToTabs();
       if (val === 0) {
         this.$nextTick(() => {
           this.initMap();
@@ -461,6 +461,17 @@ createApp({
     }
   },
   methods: {
+    scrollToTabs() {
+      this.$nextTick(() => {
+        const el = this.$refs.tabsTop ? (this.$refs.tabsTop.$el || this.$refs.tabsTop) : null;
+        if (el && el.getBoundingClientRect) {
+          const top = el.getBoundingClientRect().top + window.pageYOffset;
+          window.scrollTo({ top, behavior: 'smooth' });
+        } else {
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+      });
+    },
     savePredicted() {
       fetch('/api/predicted', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- scroll to the tab section when switching tabs instead of the top of the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871bc77f2e48331bb4016843663dffb