### PR TITLE
Add nickname registration after OAuth signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Waypoints contained in the GPX file are automatically displayed on the map and o
    report describing the run.
 7. Use the "Dark mode" button next to the upload field to switch between light
    and dark themes.
+8. Sign up with Apple or Google. After signing up the application asks for a
+   nickname, which is displayed in the header.
 
 ### Command line analysis
 

--- a/frontend/templates/vuetify.ejs
+++ b/frontend/templates/vuetify.ejs
@@ -161,6 +161,7 @@
         </div>
       </v-toolbar-title>
       <v-spacer></v-spacer>
+      <span v-if="nickname" class="mr-4">{{ nickname }}</span>
       <v-btn icon @click="introDialog = true">
         <v-icon>mdi-help-circle-outline</v-icon>
       </v-btn>
@@ -241,6 +242,19 @@
             <v-spacer></v-spacer>
             <v-btn text @click="deleteDialog = false">キャンセル</v-btn>
             <v-btn color="red" text @click="confirmDelete">削除</v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+
+      <v-dialog v-model="nicknameDialog" max-width="400">
+        <v-card>
+          <v-card-title class="text-h6">ニックネーム登録</v-card-title>
+          <v-card-text>
+            <v-text-field label="ニックネーム" v-model="newNickname"></v-text-field>
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer></v-spacer>
+            <v-btn color="primary" text @click="saveNickname">保存</v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>
@@ -546,12 +560,16 @@ createApp({
       editId: null,
       editTitleTemp: '',
       introDialog: false,
-      signupMenu: false
+      signupMenu: false,
+      nicknameDialog: false,
+      newNickname: '',
+      nickname: ''
       };
   },
   created() {
     this.loadPredicted();
     this.loadSavedList();
+    this.fetchNickname();
     if (!localStorage.getItem('introShown')) {
       this.introDialog = true;
       localStorage.setItem('introShown', '1');
@@ -642,6 +660,32 @@ createApp({
     },
     signup(provider) {
       window.location.href = `/auth/${provider}`;
+    },
+    fetchNickname() {
+      fetch('/auth/me')
+        .then(res => res.ok ? res.json() : Promise.reject())
+        .then(data => {
+          this.nickname = data.nickname || '';
+          if (data.registered && !this.nickname) {
+            this.nicknameDialog = true;
+          }
+        })
+        .catch(() => {});
+    },
+    saveNickname() {
+      const n = this.newNickname.trim();
+      if (!n) return;
+      fetch('/auth/nickname', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nickname: n })
+      })
+        .then(res => res.ok ? res.json() : Promise.reject())
+        .then(() => {
+          this.nickname = n;
+          this.nicknameDialog = false;
+        })
+        .catch(() => {});
     },
     savePredicted() {
       fetch('/api/predicted', {

--- a/user_tables.md
+++ b/user_tables.md
@@ -2,10 +2,11 @@
 
 This project uses Supabase Auth for social logins. The following table keeps a mapping between authenticated users and the anonymous `uid` cookie used before sign up.
 
-| Column     | Type        | Description                                                 |
-|------------|-------------|-------------------------------------------------------------|
-| auth_uid   | uuid        | Primary key referencing `auth.users.id`.                    |
-| uid        | uuid        | Anonymous identifier preserved from the cookie.             |
-| created_at | timestamptz | Timestamp when the record was inserted.                    |
+| Column     | Type        | Description |
+|------------|-------------|----------------------------------------------|
+| auth_uid   | uuid        | Primary key referencing `auth.users.id`. |
+| uid        | uuid        | Anonymous identifier preserved from the cookie. |
+| nickname   | text        | User chosen nickname displayed in the UI. |
+| created_at | timestamptz | Timestamp when the record was inserted. |
 
 The `auth.users` table managed by Supabase stores provider information such as email or OAuth provider. After a successful sign up, the application inserts a row into `user_meta` with the current `uid` so that existing data remains associated with the new account.


### PR DESCRIPTION
## Summary
- add `/auth/me` and `/auth/nickname` endpoints
- extend frontend to show nickname in header
- prompt for nickname when missing
- document nickname column in tables and signup step

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6873a55ddf448331896423e1789fd052