### PR TITLE
Fix signup menu remains open

### DIFF
--- a/frontend/templates/vuetify.ejs
+++ b/frontend/templates/vuetify.ejs
@@ -661,6 +661,7 @@ createApp({
       });
     },
     signup(provider) {
+      this.signupMenu = false;
       window.location.href = `/auth/${provider}`;
     },
     fetchNickname() {


### PR DESCRIPTION
## Summary
- close the signup menu before redirecting to OAuth provider

## Testing
- `node backend/test_gpxutils.js`

------
https://chatgpt.com/codex/tasks/task_e_6873a8d82e988331a8fbde9e31d8cfa2