### PR TITLE
Fix Supabase init in auth callback

### DIFF
--- a/frontend/templates/auth_callback.ejs
+++ b/frontend/templates/auth_callback.ejs
@@ -7,9 +7,10 @@
 </head>
 <body>
 <script>
-const supabase = supabase.createClient('<%= supabaseUrl %>', '<%= supabaseAnonKey %>');
+const { createClient } = supabase;
+const sb = createClient('<%= supabaseUrl %>', '<%= supabaseAnonKey %>');
 (async () => {
-  const { data, error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+  const { data, error } = await sb.auth.getSessionFromUrl({ storeSession: true });
   console.log('getSessionFromUrl', data, error);
   if (data && data.session) {
     const res = await fetch('/auth/store', {


### PR DESCRIPTION
## Summary
- fix the Supabase client initialization in the auth callback template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878dd50e1548331ba44ad2059117ab0